### PR TITLE
Add ExcludedFrameworks argument

### DIFF
--- a/mesos-tasks.py
+++ b/mesos-tasks.py
@@ -20,6 +20,8 @@ def configure_callback(conf):
             host = node.values[0]
         elif node.key == "Port":
             port = int(node.values[0])
+        elif node.key == "ExcludedFrameworks":
+            excluded_frameworks = node.values[0].lowercase.split(",")
         else:
             collectd.warning("mesos-tasks plugin: Unknown config key: %s." % node.key)
 
@@ -56,6 +58,8 @@ def read_stats(conf):
     tasks = {}
 
     for framework in state["frameworks"]:
+        if framework["name"].lowercase in excluded_frameworks:
+          continue
         for executor in framework["executors"]:
             for task in executor["tasks"]:
                 info = {}


### PR DESCRIPTION
So that we are able to remove data collection for a given framework.

Our current use-case in Aurora, as long as the task format is not the same etc. we end up having tons of matrics